### PR TITLE
Add endpoints for Option contracts

### DIFF
--- a/src/Rest/Options/Contract.php
+++ b/src/Rest/Options/Contract.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace PolygonIO\Rest\Options;
+
+use PolygonIO\Rest\RestResource;
+
+class Contract extends RestResource
+{
+    public function get($optionsTicker, $params = []): array
+    {
+        return $this->_get('/v3/reference/options/contracts/' . $optionsTicker, $params);
+    }
+}

--- a/src/Rest/Options/Contracts.php
+++ b/src/Rest/Options/Contracts.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace PolygonIO\Rest\Options;
+
+use PolygonIO\Rest\RestResource;
+
+class Contracts extends RestResource
+{
+    public function get($params = []): array
+    {
+        return $this->_get('/v3/reference/options/contracts', $params);
+    }
+}

--- a/tests/Rest/Options/ContractTest.php
+++ b/tests/Rest/Options/ContractTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace PolygonIO\Tests\Rest\Options;
+
+use PolygonIO\Rest\Options\Contract;
+use PolygonIO\Tests\Concerns\MocksHttp;
+
+class ContractTest extends \PHPUnit\Framework\TestCase
+{
+    use MocksHttp;
+
+    public function testContractGetCall()
+    {
+        $requestsContainer = [];
+
+        $contract = new Contract('fake-api-key');
+        $contract->httpClient = $this->getHttpMock(
+            $requestsContainer, [
+                'results' => [],
+            ]
+        );
+
+        $contract->get('O:EVRI240119C00002500');
+
+        $this->assertPath($requestsContainer, '/v3/reference/options/contracts/O:EVRI240119C00002500');
+    }
+}

--- a/tests/Rest/Options/ContractsTest.php
+++ b/tests/Rest/Options/ContractsTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace PolygonIO\Tests\Rest\Options;
+
+use PolygonIO\Rest\Options\Contracts;
+use PolygonIO\Tests\Concerns\MocksHttp;
+
+class ContractsTest extends \PHPUnit\Framework\TestCase
+{
+    use MocksHttp;
+
+    public function testContractGetCall()
+    {
+        $requestsContainer = [];
+
+        $contract = new Contracts('fake-api-key');
+        $contract->httpClient = $this->getHttpMock(
+            $requestsContainer, [
+                'results' => [],
+            ]
+        );
+
+        $contract->get();
+
+        $this->assertPath($requestsContainer, '/v3/reference/options/contracts');
+    }
+}


### PR DESCRIPTION
This pull request adds two option-specific endpoints.

- [Contract](https://polygon.io/docs/options/get_v3_reference_options_contracts__options_ticker)
- [Contracts](https://polygon.io/docs/options/get_v3_reference_options_contracts)